### PR TITLE
Update: adding a defaultView to the shadow root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-html-element",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/ReactHTMLElement.ts
+++ b/src/ReactHTMLElement.ts
@@ -8,6 +8,7 @@ interface LooseShadowRoot extends ShadowRoot {
 function retargetReactEvents(container: Node, shadow: LooseShadowRoot): void {
   Object.defineProperty(container, 'ownerDocument', { value: shadow });
   /* eslint-disable no-param-reassign */
+  shadow.defaultView = window;
   shadow.createElement = (
     tagName: string,
     options?: ElementCreationOptions,


### PR DESCRIPTION
Some UI libraries expect the root node to have a `defaultView`. This provides that value.