### PR TITLE
Update: ensure mouse events are on shadow root

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/src/ReactHTMLElement.ts
+++ b/src/ReactHTMLElement.ts
@@ -1,4 +1,5 @@
 import ReactDOM from 'react-dom';
+import forceRetarget from './forcedRetargeting';
 
 interface LooseShadowRoot extends ShadowRoot {
   [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -19,6 +20,7 @@ function retargetReactEvents(container: Node, shadow: LooseShadowRoot): void {
     options: ElementCreationOptions,
   ): Element => document.createElementNS(ns, tagName, options);
   shadow.createTextNode = (text: string): Text => document.createTextNode(text);
+  forceRetarget(shadow);
   /* eslint-enable no-param-reassign */
 }
 

--- a/src/forcedRetargeting.ts
+++ b/src/forcedRetargeting.ts
@@ -1,0 +1,118 @@
+// Code came from https://github.com/spring-media/react-shadow-dom-retarget-events/blob/516dafb756d8e3daaadaf9f8b48f85c6811e93e7/index.js
+/* eslint-disable no-param-reassign */
+/* eslint-disable  @typescript-eslint/explicit-function-return-type */
+const reactEvents = [
+  'onMouseDown',
+  'onMouseMove',
+  'onMouseOut',
+  'onMouseOver',
+  'onMouseUp',
+];
+
+function findReactProperty(item: any, propertyPrefix: string): any {
+  // eslint-disable-next-line no-restricted-syntax
+  for (const key in item) {
+    // eslint-disable-next-line no-prototype-builtins
+    if (item.hasOwnProperty(key) && key.includes(propertyPrefix)) {
+      return item[key];
+    }
+  }
+  return null;
+}
+
+function findReactEventHandlers(item: any): any {
+  return findReactProperty(item, '__reactEventHandlers');
+}
+
+function findReactComponent(item: any): any {
+  return findReactProperty(item, '_reactInternal');
+}
+
+function findReactProps(component: any): any {
+  if (!component) return undefined;
+  if (component.memoizedProps) return component.memoizedProps; // React 16 Fiber
+  if (component._currentElement && component._currentElement.props) return component._currentElement.props; // React <=15
+  return null;
+}
+
+function dispatchEvent(
+  event: any,
+  eventType: string,
+  componentProps: any,
+): any {
+  event.persist = function() {
+    event.isPersistent = function() {
+      return true;
+    };
+  };
+
+  if (componentProps[eventType]) {
+    componentProps[eventType](event);
+  }
+}
+
+function composedPath(el: HTMLElement | null): any {
+  const path = [];
+  while (el) {
+    path.push(el);
+    if (el.tagName === 'HTML') {
+      path.push(document);
+      path.push(window);
+      return path;
+    }
+    el = el.parentElement;
+  }
+  return [el];
+}
+
+export default function retargetEvents(shadowRoot: Node): () => void {
+  const removeEventListeners: (() => void)[] = [];
+
+  reactEvents.forEach((reactEventName) => {
+    const nativeEventName = reactEventName.replace(/^on/, '').toLowerCase();
+
+    function retargetEventListener(event: Event | any): void {
+      const path = event.path
+        || (event.composedPath && event.composedPath())
+        || composedPath(event.target);
+
+      for (let i = 0; i < path.length; i += 1) {
+        const el = path[i];
+        let props = null;
+        const reactComponent = findReactComponent(el);
+        const eventHandlers = findReactEventHandlers(el);
+
+        if (!eventHandlers) {
+          props = findReactProps(reactComponent);
+        } else {
+          props = eventHandlers;
+        }
+
+        if (reactComponent && props) {
+          dispatchEvent(event, reactEventName, props);
+        }
+
+        if (event.cancelBubble) {
+          break;
+        }
+
+        if (el === shadowRoot) {
+          break;
+        }
+      }
+    }
+
+    shadowRoot.addEventListener(nativeEventName, retargetEventListener, false);
+    removeEventListeners.push(() => shadowRoot.removeEventListener(
+        nativeEventName,
+        retargetEventListener,
+        false,
+      ));
+  });
+
+  return () => {
+    removeEventListeners.forEach((removeEventListener) => {
+      removeEventListener();
+    });
+  };
+}

--- a/src/forcedRetargeting.ts
+++ b/src/forcedRetargeting.ts
@@ -7,7 +7,6 @@ const reactEvents = [
   'onMouseOut',
   'onMouseOver',
   'onMouseUp',
-  'onClick',
 ];
 
 function findReactProperty(item: any, propertyPrefix: string): any {

--- a/src/forcedRetargeting.ts
+++ b/src/forcedRetargeting.ts
@@ -7,6 +7,7 @@ const reactEvents = [
   'onMouseOut',
   'onMouseOver',
   'onMouseUp',
+  'onClick',
 ];
 
 function findReactProperty(item: any, propertyPrefix: string): any {

--- a/src/forcedRetargeting.ts
+++ b/src/forcedRetargeting.ts
@@ -51,7 +51,9 @@ function dispatchEvent(
   }
 }
 
-function composedPath(el: HTMLElement | null): any {
+function composedPath(
+  el: HTMLElement | null,
+): (Node | (Window & typeof globalThis))[] {
   const path = [];
   while (el) {
     path.push(el);
@@ -62,7 +64,7 @@ function composedPath(el: HTMLElement | null): any {
     }
     el = el.parentElement;
   }
-  return [el];
+  return [];
 }
 
 export default function retargetEvents(shadowRoot: Node): () => void {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "target": "es5"
   },
   "include": ["src"],
-  "exclude": ["src/__tests__"]
+  "exclude": ["src/__tests__", "node_modules"]
 }


### PR DESCRIPTION
This is to support react components that use the onMouseDown, or
onMouseUp. Currently these events are still being attached to the
document instead of the shdaow root